### PR TITLE
Rename job-dsl directory to jobs

### DIFF
--- a/doc/solita.jenkins.rst
+++ b/doc/solita.jenkins.rst
@@ -40,7 +40,7 @@ With this role and the `Job DSL plugin`_, your entire Jenkins configuration can 
 
 ::
 
-    // job-dsl/main.groovy
+    // jobs/main.groovy
     job('DSL-Tutorial-1-Test') {
         scm {
             git('git://github.com/jgritman/aws-sdk-test.git')
@@ -163,7 +163,7 @@ Only update security settings and users::
 Jobs and Views
 --------------
 
-You can define jobs and views with a `Job DSL`_ script. The role looks for scripts in the directory ``job-dsl`` next to your playbook and runs the script called ``main.groovy``, which can import the other scripts in the directory.
+You can define jobs and views with a `Job DSL`_ script. The role looks for scripts in the directory ``jobs`` next to your playbook and runs the script called ``main.groovy``, which can import the other scripts in the directory.
 
 To change the Job DSL script directory, set the variable ``solita_jenkins_job_dsl_dir``.
 
@@ -176,7 +176,7 @@ Examples
 
 If you create your script in the default location, no configuration is needed::
 
-    // job-dsl/main.groovy
+    // jobs/main.groovy
     job('my-new-job') {
         // ...
     }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -66,7 +66,7 @@
     src: "{{ item }}"
     dest: /var/lib/jenkins/jobs/job-dsl/workspace
   with_fileglob:
-    - "{{ playbook_dir }}/job-dsl/*.groovy"
+    - "{{ playbook_dir }}/jobs/*.groovy"
   register: update_job_dsl_scripts_old
 
 - name: Update the Job DSL scripts (new workspace location)
@@ -77,7 +77,7 @@
     src: "{{ item }}"
     dest: /var/lib/jenkins/workspace/job-dsl
   with_fileglob:
-    - "{{ playbook_dir }}/job-dsl/*.groovy"
+    - "{{ playbook_dir }}/jobs/*.groovy"
   register: update_job_dsl_scripts_new
 
 - name: Run the Job DSL scripts

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,8 +18,8 @@ module TestHelper
 
   def ansible_playbook(args, contents, options = {})
     p = Tempfile.new('playbook.yml', '.')
-    FileUtils::mkdir_p('job-dsl')
-    m = File.new('job-dsl/main.groovy', 'w')
+    FileUtils::mkdir_p('jobs')
+    m = File.new('jobs/main.groovy', 'w')
     begin
       p.write(unindent(contents))
       p.close

--- a/test/test_jobs.rb
+++ b/test/test_jobs.rb
@@ -4,7 +4,7 @@ class TestJobs < Minitest::Test
 
   include TestHelper
 
-  # Jobs are created/modified/deleted to match job-dsl/main.groovy.
+  # Jobs are created/modified/deleted to match jobs/main.groovy.
   def test_jobs
     # Disable security.
     ansible_playbook '--tags solita_jenkins_security', <<-EOF


### PR DESCRIPTION
Due to JENKINS-32705, jenkins-cli.jar can clash with a directory named
"job-dsl". Name the directory "jobs" to avoid that.

Closes solita/solita-cd#1
