### PR TITLE
[WARNING]: when statements should not include jinja2 templating delim…

### DIFF
--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -76,7 +76,7 @@
 
 - name: Check that user variables are only used with solita_jenkins_security_realm='jenkins'
   fail: msg="User variables are only allowed with solita_jenkins_security_realm='jenkins'"
-  when: ({{ item }} | length > 0) and ((solita_jenkins_security_realm | default(None)) != 'jenkins')
+  when: (item | length > 0) and ((solita_jenkins_security_realm | default(None)) != 'jenkins')
   with_items:
     - solita_jenkins_users
     - solita_jenkins_absent_users


### PR DESCRIPTION
…iters

[WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: ({{ item }} | length > 0) and ((solita_jenkins_security_realm | default(None)) != 'jenkins')