### PR TITLE
Support running tests on Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Development
 -------------
 
 Setup a test environment by running `vagrant up` in test directory.
-Execute `vagrant ssh` and then `rake` to run unit tests.
+Execute `vagrant ssh -c rake` to run unit tests.
 
 ------------
 Contributors

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,13 @@ Documentation
 
 `Reference <http://solita-cd.readthedocs.org/en/latest/solita.jenkins.html>`_
 
+-------------
+Development
+-------------
+
+Setup a test environment by running `vagrant up` in test directory.
+Execute `vagrant ssh` and then `rake` to run unit tests.
+
 ------------
 Contributors
 ------------

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure(2) do |config|
   config.vm.box = 'ubuntu/trusty64'
 
-  config.vm.synced_folder "..", "/solita.jenkins"
+  config.vm.synced_folder "..", "/solita.jenkins" , type: "rsync", rsync__exclude: ".git/"
   config.vm.network :forwarded_port, guest: 8081, host: 9080
 
   config.vm.provider 'virtualbox' do |v|

--- a/test/test_security.rb
+++ b/test/test_security.rb
@@ -130,7 +130,8 @@ class TestSecurity < Minitest::Test
         - solita.jenkins
     EOF
 
-    # Set "foo" as the default password.
+    # Copy the default password to safety and overwrite with "foo" as the default password.
+    system 'cp environments/vagrant/solita_jenkins_default_password/solita_jenkins /tmp/solita_jenkins.bak'
     system 'echo foo >environments/vagrant/solita_jenkins_default_password/solita_jenkins'
 
     # Enable security.
@@ -160,6 +161,9 @@ class TestSecurity < Minitest::Test
 
     # The security configuration should not change.
     assert_equal File.read('/tmp/realm1.groovy'), File.read('/tmp/realm2.groovy')
+
+    # login_as reads password from solita_jenkins_default_password, we'll need to restore it
+    system 'cp /tmp/solita_jenkins.bak environments/vagrant/solita_jenkins_default_password/solita_jenkins'
   end
 
 end


### PR DESCRIPTION
The last line of install-dependencies.sh (`ln -s "$role_dir" "$test_roles_dir/$role_name"`) fails on Windows because the underlying file system doesn't support symlinks. As a workaround, use rsync to synchronize the shared directory to the guest machine.

This pull request also adds short instructions how to run tests.