### PR TITLE
Allow importing other files to Job DSL scripts

### DIFF
--- a/files/javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration.xml
+++ b/files/javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration plugin="job-dsl">
+  <category class="jenkins.model.GlobalConfigurationCategory$Security"/>
+  <useScriptSecurity>false</useScriptSecurity>
+</javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration>

--- a/tasks/security.yml
+++ b/tasks/security.yml
@@ -91,8 +91,19 @@
     force: no
   register: authorize_project
 
+- name: Disable script security for Job DSL scripts
+  become: yes
+  copy:
+    src: javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration.xml
+    dest: /var/lib/jenkins/javaposse.jobdsl.plugin.GlobalJobDslSecurityConfiguration.xml
+    owner: jenkins
+    group: jenkins
+    mode: u=rw,go=r
+    force: no
+  register: disable_script_security
+
 - include: restart.yml
-  when: (matrix_auth_plugin | changed) or (security_realm | changed) or (jnlp_port | changed) or (authorize_project | changed)
+  when: (matrix_auth_plugin | changed) or (security_realm | changed) or (jnlp_port | changed) or (authorize_project | changed) or (disable_script_security | changed)
 
 - name: Check that user variables are only used with solita_jenkins_security_realm='jenkins'
   fail: msg="User variables are only allowed with solita_jenkins_security_realm='jenkins'"


### PR DESCRIPTION
Job DSL 1.60 introduces [Script Security](https://github.com/jenkinsci/job-dsl-plugin/wiki/Script-Security) feature that unfortunately breaks a lot of old scripts that import utility classes. I propose that we disable the Script Security by default to maintain backwards compatibility.

Because of the `force: no` option end users can still enable the Script Security should they choose to.

Further information: https://github.com/jenkinsci/job-dsl-plugin/wiki/Real-World-Examples#import-other-files-ie-with-class-definitions-into-your-script